### PR TITLE
Implement role-based business console and management

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -7,8 +7,15 @@ import { Moon, Sun } from 'lucide-react'
 import { MainSidebar } from '../components/MainSidebar'
 
 const SIDEBAR_ROUTES = new Set([
-  '/', '/clientes', '/agenda', '/inventario', '/servicios',
-  '/pos', '/reportes', '/fidelizacion'
+  'dashboard',
+  'clientes',
+  'agenda',
+  'inventario',
+  'servicios',
+  'pos',
+  'reportes',
+  'fidelizacion',
+  'usuarios',
 ])
 
 function useDarkMode() {
@@ -24,8 +31,8 @@ function useDarkMode() {
   return { dark, toggle }
 }
 
-function useHeaderTitle(pathname: string) {
-  const k = pathname === '/' ? 'dashboard' : pathname.split('/')[1]
+function useHeaderTitle(section: string) {
+  const k = section || 'dashboard'
   switch (k) {
     case 'clientes': return 'Gestión de Clientes'
     case 'agenda': return 'Agenda de Citas'
@@ -34,16 +41,18 @@ function useHeaderTitle(pathname: string) {
     case 'pos': return 'Punto de Venta'
     case 'reportes': return 'Reportes'
     case 'fidelizacion': return 'Fidelización'
+    case 'usuarios': return 'Gestión de usuarios'
     default: return 'Dashboard'
   }
 }
 
 export default function AppShell() {
   const { pathname } = useLocation()
-  const base = pathname === '/' ? '/' : `/${pathname.split('/')[1]}`
-  const showSidebar = SIDEBAR_ROUTES.has(base)
+  const segments = pathname.split('/').filter(Boolean)
+  const section = segments[2] ?? 'dashboard'
+  const showSidebar = segments[0] === 'business' && SIDEBAR_ROUTES.has(section)
   const { dark, toggle } = useDarkMode()
-  const title = useHeaderTitle(pathname)
+  const title = useHeaderTitle(section)
 
   return (
     <SidebarProvider>

--- a/src/app/providers/AuthProvider.tsx
+++ b/src/app/providers/AuthProvider.tsx
@@ -1,0 +1,104 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { User } from 'firebase/auth'
+import { onAuthStateChanged } from 'firebase/auth'
+import { doc, getDoc, onSnapshot, serverTimestamp, setDoc, type Unsubscribe } from 'firebase/firestore'
+import { auth, db } from '../../lib/firebase'
+import type { UserProfile } from '../types'
+
+export type AuthContextValue = {
+  user: User | null
+  profile: UserProfile | null
+  loading: boolean
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let profileUnsub: Unsubscribe | null = null
+
+    const unsub = onAuthStateChanged(auth, async (firebaseUser) => {
+      try {
+        setUser(firebaseUser)
+        if (profileUnsub) {
+          profileUnsub()
+          profileUnsub = null
+        }
+
+        if (!firebaseUser) {
+          setProfile(null)
+          setLoading(false)
+          return
+        }
+
+        const userRef = doc(db, 'users', firebaseUser.uid)
+        const snapshot = await getDoc(userRef)
+
+        if (!snapshot.exists()) {
+          await setDoc(userRef, {
+            uid: firebaseUser.uid,
+            email: firebaseUser.email ?? '',
+            name: firebaseUser.displayName ?? null,
+            photoURL: firebaseUser.photoURL ?? null,
+            businesses: {},
+            createdAt: serverTimestamp(),
+            lastLogin: serverTimestamp(),
+          })
+        } else {
+          await setDoc(
+            userRef,
+            {
+              uid: firebaseUser.uid,
+              email: firebaseUser.email ?? '',
+              name: firebaseUser.displayName ?? null,
+              photoURL: firebaseUser.photoURL ?? null,
+              lastLogin: serverTimestamp(),
+            },
+            { merge: true },
+          )
+        }
+
+        profileUnsub = onSnapshot(userRef, (snap) => {
+          const data = snap.data() as UserProfile | undefined
+          setProfile(
+            data
+              ? {
+                  ...data,
+                  businesses: data.businesses ?? {},
+                }
+              : null,
+          )
+          setLoading(false)
+        })
+      } catch (error) {
+        console.error('AuthProvider error', error)
+        setProfile(null)
+        setLoading(false)
+      } finally {
+      }
+    })
+
+    return () => {
+      unsub()
+      if (profileUnsub) profileUnsub()
+    }
+  }, [])
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ user, profile, loading }),
+    [loading, profile, user],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider')
+  return ctx
+}

--- a/src/app/providers/BusinessProvider.tsx
+++ b/src/app/providers/BusinessProvider.tsx
@@ -1,0 +1,86 @@
+import { createContext, useContext, useMemo, useCallback } from 'react'
+import type { ReactNode } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { collection, doc, getDoc, getDocs } from 'firebase/firestore'
+import { db } from '../../lib/firebase'
+import type { Business, BusinessMember } from '../types'
+import type { Role } from '../roles'
+import { useAuth } from './AuthProvider'
+
+export type BusinessContextValue = {
+  business: Business
+  role: Role
+  members: BusinessMember[]
+  membersLoading: boolean
+  refreshMembers: () => Promise<BusinessMember[] | undefined>
+}
+
+const BusinessContext = createContext<BusinessContextValue | undefined>(undefined)
+
+async function fetchBusiness(businessId: string) {
+  const ref = doc(db, 'businesses', businessId)
+  const snap = await getDoc(ref)
+  if (!snap.exists()) throw new Error('Business not found')
+  return { id: snap.id, ...snap.data() } as Business
+}
+
+async function fetchMembers(businessId: string) {
+  const col = collection(db, 'businesses', businessId, 'members')
+  const snap = await getDocs(col)
+  return snap.docs.map((docSnap) => ({
+    uid: docSnap.id,
+    ...(docSnap.data() as Omit<BusinessMember, 'uid'>),
+  })) as BusinessMember[]
+}
+
+export function BusinessProvider({ businessId, children }: { businessId: string; children: ReactNode }) {
+  const { profile, loading: authLoading } = useAuth()
+  const role = (profile?.businesses?.[businessId] ?? null) as Role | null
+
+  const businessQuery = useQuery({
+    queryKey: ['business', businessId],
+    queryFn: () => fetchBusiness(businessId),
+    enabled: Boolean(businessId),
+  })
+
+  const membersQuery = useQuery({
+    queryKey: ['business-members', businessId],
+    queryFn: () => fetchMembers(businessId),
+    enabled: Boolean(businessId && role),
+  })
+
+  const { data: membersData, isPending: membersPending, refetch: refetchMembersQuery } = membersQuery
+
+  if (authLoading || businessQuery.isLoading) {
+    return <div className="p-6">Cargando negocio...</div>
+  }
+
+  if (!businessId || !role || !businessQuery.data) {
+    return <Navigate to="/" replace />
+  }
+
+  const refreshMembers = useCallback(async () => {
+    const fresh = await refetchMembersQuery()
+    return fresh.data
+  }, [refetchMembersQuery])
+
+  const value = useMemo<BusinessContextValue>(
+    () => ({
+      business: businessQuery.data!,
+      role: role!,
+      members: membersData ?? [],
+      membersLoading: membersPending,
+      refreshMembers,
+    }),
+    [businessQuery.data, membersData, membersPending, refreshMembers, role],
+  )
+
+  return <BusinessContext.Provider value={value}>{children}</BusinessContext.Provider>
+}
+
+export function useBusiness() {
+  const ctx = useContext(BusinessContext)
+  if (!ctx) throw new Error('useBusiness must be used inside BusinessProvider')
+  return ctx
+}

--- a/src/app/roles.ts
+++ b/src/app/roles.ts
@@ -1,0 +1,20 @@
+export const ROLE = {
+  Owner: 'owner',
+  Admin: 'admin',
+  Manager: 'manager',
+  Staff: 'staff',
+  Guest: 'guest',
+} as const
+
+export type Role = (typeof ROLE)[keyof typeof ROLE]
+
+export const ROLE_LABELS: Record<Role, string> = {
+  [ROLE.Owner]: 'Propietario',
+  [ROLE.Admin]: 'Administrador',
+  [ROLE.Manager]: 'Gerente',
+  [ROLE.Staff]: 'Empleado',
+  [ROLE.Guest]: 'Colaborador',
+}
+
+export const PRIVILEGED_ROLES: Role[] = [ROLE.Owner, ROLE.Admin]
+export const MANAGEMENT_ROLES: Role[] = [ROLE.Owner, ROLE.Admin, ROLE.Manager]

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,7 +1,9 @@
-import { createBrowserRouter } from 'react-router-dom'
+import { createBrowserRouter, Navigate, useParams } from 'react-router-dom'
 import Login from '../pages/Login'
 import ProtectedRoute from '../components/ProtectedRoute'
 import AppShell from './AppShell'
+import ConsolePage from '../pages/ConsolePage'
+import { BusinessProvider } from './providers/BusinessProvider'
 
 // Páginas/ módulos (los tuyos)
 import {Dashboard} from '../pages/Dashboard'
@@ -12,6 +14,17 @@ import {POSPage} from '../features/pos/POSPage'
 import AgendaPage from '../features/agenda/AgendaPage'
 import FidelizacionPage from '../features/fidelizacion/FidelizacionPage'
 import { ReportPage } from '../features/reportes/ReportPage'
+import UserManagementPage from '../features/users/UserManagementPage'
+
+function BusinessRouteLayout() {
+  const { businessId } = useParams<{ businessId: string }>()
+  if (!businessId) return <Navigate to="/" replace />
+  return (
+    <BusinessProvider businessId={businessId}>
+      <AppShell />
+    </BusinessProvider>
+  )
+}
 
 
 export const router = createBrowserRouter([
@@ -20,7 +33,15 @@ export const router = createBrowserRouter([
     path: '/',
     element: (
       <ProtectedRoute>
-        <AppShell />
+        <ConsolePage />
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/business/:businessId',
+    element: (
+      <ProtectedRoute>
+        <BusinessRouteLayout />
       </ProtectedRoute>
     ),
     children: [
@@ -32,6 +53,7 @@ export const router = createBrowserRouter([
       { path: 'servicios', element: <ServicesPage /> },
       { path: 'pos', element: <POSPage /> },
       { path: 'reportes', element: <ReportPage /> },
+      { path: 'usuarios', element: <UserManagementPage /> },
     ],
   },
 ])

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,33 @@
+import type { Timestamp } from 'firebase/firestore'
+import type { Role } from './roles'
+
+export type UserProfile = {
+  uid: string
+  email: string
+  name: string | null
+  photoURL: string | null
+  businesses: Record<string, Role>
+  createdAt?: Timestamp
+  lastLogin?: Timestamp
+}
+
+export type BusinessSettings = {
+  currency: string
+  timezone: string
+}
+
+export type Business = {
+  id: string
+  name: string
+  ownerId: string
+  createdAt?: Timestamp
+  updatedAt?: Timestamp
+  settings?: BusinessSettings
+}
+
+export type BusinessMember = {
+  uid: string
+  email: string
+  role: Role
+  addedAt?: Timestamp
+}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,21 +1,12 @@
-import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
-import { onAuthStateChanged } from 'firebase/auth'
-import { useNavigate } from 'react-router-dom'
-import { auth } from '../lib/firebase'
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuth } from '../app/providers/AuthProvider'
 
 export default function ProtectedRoute({ children }: { children: ReactNode }) {
-  const navigate = useNavigate()
-  const [ready, setReady] = useState(false)
+  const { user, loading } = useAuth()
+  const location = useLocation()
 
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (user) => {
-      if (!user) navigate('/login')
-      setReady(true)
-    })
-    return () => unsub()
-  }, [navigate])
-
-  if (!ready) return <div>Cargando...</div>
+  if (loading) return <div className="p-6">Cargando...</div>
+  if (!user) return <Navigate to="/login" replace state={{ from: location }} />
   return <>{children}</>
 }

--- a/src/features/users/UserManagementPage.tsx
+++ b/src/features/users/UserManagementPage.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+import { collection, deleteDoc, doc, getDocs, query, serverTimestamp, setDoc, updateDoc, where, deleteField } from 'firebase/firestore'
+import { db } from '../../lib/firebase'
+import { useBusiness } from '../../app/providers/BusinessProvider'
+import type { Role } from '../../app/roles'
+import { ROLE, ROLE_LABELS, PRIVILEGED_ROLES } from '../../app/roles'
+import type { BusinessMember } from '../../app/types'
+import { useAuth } from '../../app/providers/AuthProvider'
+
+const GMAIL_DOMAIN = '@gmail.com'
+
+function getAssignableRoles(currentRole: Role) {
+  if (currentRole === ROLE.Owner) return [ROLE.Admin, ROLE.Manager, ROLE.Staff, ROLE.Guest, ROLE.Owner]
+  if (currentRole === ROLE.Admin) return [ROLE.Admin, ROLE.Manager, ROLE.Staff, ROLE.Guest]
+  return []
+}
+
+function canEditMember(currentRole: Role, member: BusinessMember) {
+  if (member.role === ROLE.Owner && currentRole !== ROLE.Owner) return false
+  if (member.role === ROLE.Admin && currentRole !== ROLE.Owner) return false
+  return true
+}
+
+export default function UserManagementPage() {
+  const { business, role, members, membersLoading, refreshMembers } = useBusiness()
+  const { user } = useAuth()
+  const [email, setEmail] = useState('')
+  const [selectedRole, setSelectedRole] = useState<Role>(() => getAssignableRoles(role)[0] ?? ROLE.Manager)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const assignableRoles = useMemo(() => getAssignableRoles(role), [role])
+
+  useEffect(() => {
+    if (!assignableRoles.includes(selectedRole)) {
+      setSelectedRole(assignableRoles[0] ?? ROLE.Manager)
+    }
+  }, [assignableRoles, selectedRole])
+
+  if (!PRIVILEGED_ROLES.includes(role)) {
+    return (
+      <div className="rounded-lg border p-6 text-sm text-muted-foreground">
+        No tienes permiso para gestionar usuarios en este negocio.
+      </div>
+    )
+  }
+
+  const handleInvite = async (event: FormEvent) => {
+    event.preventDefault()
+    setError(null)
+    setSuccess(null)
+    if (!email.endsWith(GMAIL_DOMAIN)) {
+      setError('Solo se permiten invitaciones a correos de Gmail.')
+      return
+    }
+    setBusy(true)
+    try {
+      const normalizedEmail = email.trim().toLowerCase()
+      const existing = members.find((member) => member.email.toLowerCase() === normalizedEmail)
+      if (existing) {
+        setError('Este usuario ya es miembro del negocio.')
+        setBusy(false)
+        return
+      }
+
+      const usersRef = collection(db, 'users')
+      const snapshot = await getDocs(query(usersRef, where('email', '==', normalizedEmail)))
+      if (snapshot.empty) {
+        setError('No encontramos una cuenta registrada con ese correo. Pide al usuario que inicie sesión primero.')
+        setBusy(false)
+        return
+      }
+
+      const userDoc = snapshot.docs[0]
+      const invitedUid = userDoc.id
+
+      await setDoc(
+        doc(db, 'businesses', business.id, 'members', invitedUid),
+        {
+          uid: invitedUid,
+          email: normalizedEmail,
+          role: selectedRole,
+          addedAt: serverTimestamp(),
+        },
+        { merge: true },
+      )
+
+      await setDoc(
+        doc(db, 'users', invitedUid),
+        { businesses: { [business.id]: selectedRole } },
+        { merge: true },
+      )
+
+      setSuccess('Invitación enviada correctamente.')
+      setEmail('')
+      setSelectedRole(assignableRoles[0] ?? ROLE.Manager)
+      await refreshMembers()
+    } catch (err) {
+      console.error(err)
+      setError('No se pudo enviar la invitación. Intenta de nuevo.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleChangeRole = async (member: BusinessMember, nextRole: Role) => {
+    if (member.role === nextRole) return
+    if (!canEditMember(role, member)) return
+    if (role !== ROLE.Owner && nextRole === ROLE.Admin) return
+    if (role !== ROLE.Owner && nextRole === ROLE.Owner) return
+
+    try {
+      await setDoc(
+        doc(db, 'businesses', business.id, 'members', member.uid),
+        {
+          uid: member.uid,
+          email: member.email,
+          role: nextRole,
+        },
+        { merge: true },
+      )
+
+      await setDoc(
+        doc(db, 'users', member.uid),
+        { businesses: { [business.id]: nextRole } },
+        { merge: true },
+      )
+
+      if (role === ROLE.Owner && nextRole === ROLE.Owner) {
+        await updateDoc(doc(db, 'businesses', business.id), { ownerId: member.uid })
+      }
+
+      await refreshMembers()
+    } catch (error) {
+      console.error(error)
+      setError('No se pudo actualizar el rol. Intenta nuevamente.')
+    }
+  }
+
+  const handleRemove = async (member: BusinessMember) => {
+    if (!canEditMember(role, member)) return
+    if (member.uid === user?.uid) return
+
+    try {
+      await deleteDoc(doc(db, 'businesses', business.id, 'members', member.uid))
+      await updateDoc(doc(db, 'users', member.uid), {
+        [`businesses.${business.id}`]: deleteField(),
+      })
+      await refreshMembers()
+    } catch (error) {
+      console.error(error)
+      setError('No se pudo quitar el acceso. Intenta más tarde.')
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Gestión de usuarios</h1>
+        <p className="text-sm text-muted-foreground">
+          Invita colaboradores y asigna roles según sus responsabilidades.
+        </p>
+      </header>
+
+      <section className="rounded-lg border p-6">
+        <h2 className="text-lg font-semibold">Invitar colaborador</h2>
+        <form onSubmit={handleInvite} className="mt-4 grid gap-4 md:grid-cols-[2fr,1fr,auto] items-center">
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="correo@gmail.com"
+            className="h-10 rounded-md border px-3"
+          />
+          <select
+            value={selectedRole}
+            onChange={(event) => setSelectedRole(event.target.value as Role)}
+            className="h-10 rounded-md border px-3"
+          >
+            {assignableRoles.map((roleOption) => (
+              <option key={roleOption} value={roleOption}>
+                {ROLE_LABELS[roleOption]}
+              </option>
+            ))}
+          </select>
+          <button
+            type="submit"
+            disabled={busy}
+            className="inline-flex h-10 items-center rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground disabled:opacity-60"
+          >
+            {busy ? 'Enviando...' : 'Invitar'}
+          </button>
+        </form>
+        {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+        {success && <p className="mt-3 text-sm text-green-600">{success}</p>}
+      </section>
+
+      <section className="rounded-lg border">
+        <header className="flex items-center justify-between border-b px-4 py-3">
+          <h2 className="font-semibold">Miembros</h2>
+          {membersLoading && <span className="text-xs text-muted-foreground">Actualizando...</span>}
+        </header>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2">Usuario</th>
+                <th className="px-4 py-2">Rol</th>
+                <th className="px-4 py-2 text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => (
+                <tr key={member.uid} className="border-t">
+                  <td className="px-4 py-2">
+                    <div className="font-medium">{member.email}</div>
+                    <div className="text-xs text-muted-foreground">UID: {member.uid}</div>
+                  </td>
+                  <td className="px-4 py-2">
+                    {canEditMember(role, member) ? (
+                      <select
+                        value={member.role}
+                        onChange={(event) => handleChangeRole(member, event.target.value as Role)}
+                        className="h-9 rounded-md border px-2"
+                      >
+                        <option value={member.role}>{ROLE_LABELS[member.role]}</option>
+                        {getAssignableRoles(role)
+                          .filter((roleOption) => roleOption !== member.role)
+                          .map((roleOption) => (
+                            <option key={roleOption} value={roleOption}>
+                              {ROLE_LABELS[roleOption]}
+                            </option>
+                          ))}
+                      </select>
+                    ) : (
+                      <span>{ROLE_LABELS[member.role]}</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    {canEditMember(role, member) && member.uid !== user?.uid ? (
+                      <button
+                        onClick={() => handleRemove(member)}
+                        className="text-sm text-destructive hover:underline"
+                      >
+                        Quitar acceso
+                      </button>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">Sin acciones</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/hooks/useRole.ts
+++ b/src/hooks/useRole.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react'
+import type { Role } from '../app/roles'
+import { useAuth } from '../app/providers/AuthProvider'
+
+export function useRole(businessId?: string | null) {
+  const { profile } = useAuth()
+
+  return useMemo(() => {
+    if (!businessId) return null
+    const value = profile?.businesses?.[businessId]
+    if (!value) return null
+    return value as Role
+  }, [businessId, profile?.businesses])
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { router } from './app/router'
+import { AuthProvider } from './app/providers/AuthProvider'
 import "./index.css";
 
 const qc = new QueryClient()
@@ -10,7 +11,9 @@ const qc = new QueryClient()
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={qc}>
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
     </QueryClientProvider>
   </React.StrictMode>
 )

--- a/src/pages/ConsolePage.tsx
+++ b/src/pages/ConsolePage.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { collection, doc, serverTimestamp, setDoc, getDoc } from 'firebase/firestore'
+import { db } from '../lib/firebase'
+import { useAuth } from '../app/providers/AuthProvider'
+import type { Business } from '../app/types'
+import type { Role } from '../app/roles'
+import { ROLE, ROLE_LABELS } from '../app/roles'
+
+const DEFAULT_SETTINGS = { currency: 'MXN', timezone: 'America/Mexico_City' }
+
+type BusinessSummary = {
+  business: Business
+  role: Role
+}
+
+async function fetchBusiness(id: string) {
+  const ref = doc(db, 'businesses', id)
+  const snap = await getDoc(ref)
+  if (!snap.exists()) return null
+  return { id: snap.id, ...snap.data() } as Business
+}
+
+export default function ConsolePage() {
+  const { user, profile } = useAuth()
+  const navigate = useNavigate()
+
+  const membershipEntries = useMemo(() => Object.entries(profile?.businesses ?? {}), [profile?.businesses])
+
+  const summariesQuery = useQuery({
+    queryKey: ['console-businesses', profile?.uid, membershipEntries],
+    queryFn: async () => {
+      const results = await Promise.all(
+        membershipEntries.map(async ([id, role]) => {
+          const business = await fetchBusiness(id)
+          if (!business) return null
+          return { business, role: role as Role }
+        }),
+      )
+      return results.filter(Boolean) as BusinessSummary[]
+    },
+    enabled: membershipEntries.length > 0,
+  })
+
+  const ownerBusinesses = summariesQuery.data?.filter((item) => item.role === ROLE.Owner) ?? []
+  const collaboratorBusinesses = summariesQuery.data?.filter((item) => item.role !== ROLE.Owner) ?? []
+
+  const handleCreateBusiness = async () => {
+    if (!user) return
+    const name = window.prompt('Nombre del negocio')?.trim()
+    if (!name) return
+
+    try {
+      const businessRef = doc(collection(db, 'businesses'))
+      await setDoc(businessRef, {
+        id: businessRef.id,
+        name,
+        ownerId: user.uid,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        settings: DEFAULT_SETTINGS,
+      })
+
+      await setDoc(
+        doc(db, 'businesses', businessRef.id, 'members', user.uid),
+        {
+          uid: user.uid,
+          email: user.email ?? '',
+          role: ROLE.Owner,
+          addedAt: serverTimestamp(),
+        },
+        { merge: true },
+      )
+
+      await setDoc(
+        doc(db, 'users', user.uid),
+        { businesses: { [businessRef.id]: ROLE.Owner } },
+        { merge: true },
+      )
+    } catch (error) {
+      console.error('No se pudo crear el negocio', error)
+      window.alert('No se pudo crear el negocio. Intenta nuevamente.')
+    }
+  }
+
+  const loading = summariesQuery.isLoading && membershipEntries.length > 0
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold">Tu consola</h1>
+        <p className="text-muted-foreground">
+          Administra y accede a los negocios donde colaboras.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Tus negocios</h2>
+          <button
+            onClick={handleCreateBusiness}
+            className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow hover:bg-primary/90"
+          >
+            Crear negocio
+          </button>
+        </div>
+        {loading && <div>Cargando negocios...</div>}
+        {!loading && ownerBusinesses.length === 0 && (
+          <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+            Aún no tienes negocios creados. Usa el botón “Crear negocio” para comenzar.
+          </div>
+        )}
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {ownerBusinesses.map(({ business, role }) => (
+            <article
+              key={business.id}
+              className="rounded-xl border bg-card p-5 shadow-sm transition hover:shadow-md"
+            >
+              <header className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold">{business.name}</h3>
+                  <p className="text-xs text-muted-foreground">{ROLE_LABELS[role]}</p>
+                </div>
+              </header>
+              <div className="mt-4 flex items-center justify-between">
+                <div className="text-xs text-muted-foreground">
+                  ID: {business.id}
+                </div>
+                <button
+                  onClick={() => navigate(`/business/${business.id}`)}
+                  className="rounded-md border px-3 py-1 text-sm font-medium hover:bg-accent"
+                >
+                  Entrar
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Negocios con acceso</h2>
+        {loading && <div>Cargando negocios...</div>}
+        {!loading && collaboratorBusinesses.length === 0 && (
+          <div className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+            No tienes invitaciones activas todavía.
+          </div>
+        )}
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {collaboratorBusinesses.map(({ business, role }) => (
+            <article
+              key={business.id}
+              className="rounded-xl border bg-card p-5 shadow-sm transition hover:shadow-md"
+            >
+              <header className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold">{business.name}</h3>
+                  <p className="text-xs text-muted-foreground">{ROLE_LABELS[role]}</p>
+                </div>
+              </header>
+              <div className="mt-4 flex items-center justify-between">
+                <div className="text-xs text-muted-foreground">
+                  ID: {business.id}
+                </div>
+                <button
+                  onClick={() => navigate(`/business/${business.id}`)}
+                  className="rounded-md border px-3 py-1 text-sm font-medium hover:bg-accent"
+                >
+                  Entrar
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add auth and business context providers with Firestore sync and membership loading
- introduce a console view for managing businesses and create role-based navigation within business routes
- add user management tools gated by owner/admin roles and update routing, sidebar, and guards for role awareness

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d952c83a708331a2a37faf95bce7c3